### PR TITLE
Fix Git Checkout Issues

### DIFF
--- a/bicyclelaunch.sh
+++ b/bicyclelaunch.sh
@@ -44,14 +44,26 @@ jq -c '.sensors[]' "$CONFIG_FILE" | while read sensor; do
     # Checkout the specified version (branch, tag, or commit hash)
     if git -C "$SENSOR_PATH" rev-parse --verify "$GIT_VERSION" &>/dev/null; then
         echo "Checking out commit $GIT_VERSION for $NAME..." | tee -a bicycleinit.log
-        git -C "$SENSOR_PATH" checkout "$GIT_VERSION"
+        if ! git -C "$SENSOR_PATH" checkout "$GIT_VERSION"; then
+            echo "Error: Failed to checkout commit $GIT_VERSION for $NAME." | tee -a bicycleinit.log
+            continue
+        fi
     elif git -C "$SENSOR_PATH" rev-parse --verify "origin/$GIT_VERSION" &>/dev/null; then
         echo "Checking out branch $GIT_VERSION for $NAME..." | tee -a bicycleinit.log
-        git -C "$SENSOR_PATH" checkout "$GIT_VERSION"
-        git -C "$SENSOR_PATH" pull origin "$GIT_VERSION"
+        if ! git -C "$SENSOR_PATH" checkout "origin/$GIT_VERSION"; then
+            echo "Error: Failed to checkout branch $GIT_VERSION for $NAME." | tee -a bicycleinit.log
+            continue
+        fi
+        if ! git -C "$SENSOR_PATH" pull origin "$GIT_VERSION"; then
+            echo "Error: Failed to pull latest changes for branch $GIT_VERSION for $NAME." | tee -a bicycleinit.log
+            continue
+        fi
     elif git -C "$SENSOR_PATH" rev-parse --verify "refs/tags/$GIT_VERSION" &>/dev/null; then
         echo "Checking out tag $GIT_VERSION for $NAME..." | tee -a bicycleinit.log
-        git -C "$SENSOR_PATH" checkout "tags/$GIT_VERSION"
+        if ! git -C "$SENSOR_PATH" checkout "refs/tags/$GIT_VERSION"; then
+            echo "Error: Failed to checkout tag $GIT_VERSION for $NAME." | tee -a bicycleinit.log
+            continue
+        fi
     else
         echo "Error: $GIT_VERSION is not a valid branch, tag, or commit hash for $NAME." | tee -a bicycleinit.log
         continue


### PR DESCRIPTION
- Corrected tag checkout syntax to use full reference path.
- Added error handling for `git checkout` and `git pull` commands.
- Clarified checkout commands for branches and tags to avoid ambiguity.