### PR TITLE
Restart bluetooth.service after each boot

### DIFF
--- a/bicyclelaunch.sh
+++ b/bicyclelaunch.sh
@@ -17,6 +17,9 @@ mkdir -p "$SENSOR_DIR"
 # Extract the hash from the .bicycledata file
 HASH=$(jq -r '.hash' < .bicycledata)
 
+# Restart bluetooth.service
+systemctl restart bluetooth.service
+
 # Iterate through each sensor entry in the config file
 jq -c '.sensors[]' "$CONFIG_FILE" | while read sensor; do
     # Extract sensor details using jq


### PR DESCRIPTION
This should *not* be needed. But we tested that if the hotspot provider changed since last boot, restarting `bluetooth.service` before trying to connect to Varia seems to make things work. Would be good to revisit this and find the real cause.

It's a change with very little negative impact, but maybe still needs more testing before merging.

## Testing

Just change that line in `bicycleinit/bicycleinit.sh` locally on the RaspberryPi and:
1. Turn off Pi.
2. Provide hotspot from a different phone (might be useful if they also differ 2.4GHz vs 5GHz). Turn off original hostpot, turn on new hotspot.
3. Varia: turn off and back on
4. Turn on Pi.

It should happily send Varia data to the server. But one can check locally that there is the following error in the logs of `systemctl status bicycleinit.service`. 

```bash
Sep 27 12:53:31 rpi systemd[1]: Started bicycleinit.service - bicycleinit instance.
Sep 27 12:53:38 rpi bicycleinit.sh[1936]: Exception in thread Thread-2 (worker_main):
Sep 27 12:53:38 rpi bicycleinit.sh[1936]: Traceback (most recent call last):
Sep 27 12:53:38 rpi bicycleinit.sh[1936]:   File "/home/vti/bicycleinit/.env/lib/python3.11/site-packages/bleak/backends/bluezdbus/client.py", line 214, in connect
Sep 27 12:53:38 rpi bicycleinit.sh[1936]:     reply = await self._bus.call(
Sep 27 12:53:38 rpi bicycleinit.sh[1936]:             ^^^^^^^^^^^^^^^^^^^^^
Sep 27 12:53:38 rpi bicycleinit.sh[1936]:   File "/home/vti/bicycleinit/.env/lib/python3.11/site-packages/dbus_fast/aio/message_bus.py", line 398, in call
Sep 27 12:53:38 rpi bicycleinit.sh[1936]:     await future
Sep 27 12:53:38 rpi bicycleinit.sh[1936]: asyncio.exceptions.CancelledError
Sep 27 12:53:38 rpi bicycleinit.sh[1936]: During handling of the above exception, another exception occurred:
Sep 27 12:53:38 rpi bicycleinit.sh[1936]: Traceback (most recent call last):
Sep 27 12:53:38 rpi bicycleinit.sh[1936]:   File "/usr/lib/python3.11/threading.py", line 1038, in _bootstrap_inner
Sep 27 12:53:38 rpi bicycleinit.sh[1936]:     self.run()
Sep 27 12:53:38 rpi bicycleinit.sh[1936]:   File "/usr/lib/python3.11/threading.py", line 975, in run
Sep 27 12:53:38 rpi bicycleinit.sh[1936]:     self._target(*self._args, **self._kwargs)
Sep 27 12:53:38 rpi bicycleinit.sh[1936]:   File "/home/vti/bicycleinit/sensors/VTIGarminVariaRCT23011/radar-GarminVariaRCT23011.py", line 90, in worker_main
Sep 27 12:53:38 rpi bicycleinit.sh[1936]:     asyncio.run(self.radar())
Sep 27 12:53:38 rpi bicycleinit.sh[1936]:   File "/usr/lib/python3.11/asyncio/runners.py", line 190, in run
Sep 27 12:53:38 rpi bicycleinit.sh[1936]:     return runner.run(main)
Sep 27 12:53:38 rpi bicycleinit.sh[1936]:            ^^^^^^^^^^^^^^^^
Sep 27 12:53:38 rpi bicycleinit.sh[1936]:   File "/usr/lib/python3.11/asyncio/runners.py", line 118, in run
Sep 27 12:53:38 rpi bicycleinit.sh[1936]:     return self._loop.run_until_complete(task)
Sep 27 12:53:38 rpi bicycleinit.sh[1936]:            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
Sep 27 12:53:38 rpi bicycleinit.sh[1936]:   File "/usr/lib/python3.11/asyncio/base_events.py", line 653, in run_until_complete
Sep 27 12:53:38 rpi bicycleinit.sh[1936]:     return future.result()
Sep 27 12:53:38 rpi bicycleinit.sh[1936]:            ^^^^^^^^^^^^^^^
Sep 27 12:53:38 rpi bicycleinit.sh[1936]:   File "/home/vti/bicycleinit/sensors/VTIGarminVariaRCT23011/radar-GarminVariaRCT23011.py", line 153, in radar
Sep 27 12:53:38 rpi bicycleinit.sh[1936]:     await self.connect(varia)
Sep 27 12:53:38 rpi bicycleinit.sh[1936]:   File "/home/vti/bicycleinit/sensors/VTIGarminVariaRCT23011/radar-GarminVariaRCT23011.py", line 134, in connect
Sep 27 12:53:38 rpi bicycleinit.sh[1936]:     async with BleakClient(device) as client:
Sep 27 12:53:38 rpi bicycleinit.sh[1936]:   File "/home/vti/bicycleinit/.env/lib/python3.11/site-packages/bleak/__init__.py", line 570, in __aenter__
Sep 27 12:53:38 rpi bicycleinit.sh[1936]:     await self.connect()
Sep 27 12:53:38 rpi bicycleinit.sh[1936]:   File "/home/vti/bicycleinit/.env/lib/python3.11/site-packages/bleak/__init__.py", line 615, in connect
Sep 27 12:53:38 rpi bicycleinit.sh[1936]:     return await self._backend.connect(**kwargs)
Sep 27 12:53:38 rpi bicycleinit.sh[1936]:            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
Sep 27 12:53:38 rpi bicycleinit.sh[1936]:   File "/home/vti/bicycleinit/.env/lib/python3.11/site-packages/bleak/backends/bluezdbus/client.py", line 151, in connect
Sep 27 12:53:38 rpi bicycleinit.sh[1936]:     async with async_timeout(timeout):
Sep 27 12:53:38 rpi bicycleinit.sh[1936]:   File "/usr/lib/python3.11/asyncio/timeouts.py", line 98, in __aexit__
Sep 27 12:53:38 rpi bicycleinit.sh[1936]:     raise TimeoutError
Sep 27 12:53:38 rpi bicycleinit.sh[1936]: TimeoutError

```
Manually (after failed start of the varia script), one can check that a paired and trusted Varia cannot be connected to even from `bluetoothctl`. But as soon as one restarts BT service, things work as they should. Not sure what it is about the restart that works. It clearly isn't cache issues as cache isn't cleared on restart (and clearing it without restart doesn't help either).

```
vti@rpi:~$ bluetoothctl
Agent registered
[bluetooth]# connect C1:1A:18:51:69:FC 
Attempting to connect to C1:1A:18:51:69:FC
[CHG] Device C1:1A:18:51:69:FC Connected: yes
Failed to connect: org.bluez.Error.Failed le-connection-abort-by-local
[CHG] Device C1:1A:18:51:69:FC Connected: no
[bluetooth]# 
             quit

vti@rpi:~$ sudo su -
root@rpi:/var/lib/bluetooth/EC:75:0C:5E:B8:06# rm -rf cache/*
root@rpi:/var/lib/bluetooth/EC:75:0C:5E:B8:06#
vti@rpi:~/bicycleinit/sensors/VTIGarminVariaRCT23011/log $ bluetoothctl
Agent registered
[bluetooth]# connect C1:1A:18:51:69:FC 
Attempting to connect to C1:1A:18:51:69:FC
[CHG] Device C1:1A:18:51:69:FC Connected: yes
Failed to connect: org.bluez.Error.Failed le-connection-abort-by-local
[CHG] Device C1:1A:18:51:69:FC Connected: no
[bluetooth]# devices Paired
Device C1:1A:18:51:69:FC RCT716-23011
[bluetooth]# devices Trusted
Device C1:1A:18:51:69:FC RCT716-23011
[bluetooth]# connect C1:1A:18:51:69:FC 
Attempting to connect to C1:1A:18:51:69:FC
[CHG] Device C1:1A:18:51:69:FC Connected: yes
Failed to connect: org.bluez.Error.Failed le-connection-abort-by-local
[CHG] Device C1:1A:18:51:69:FC Connected: no
[bluetooth]# 
             quit

vti@rpi:~$ systemctl restart bluetooth.service 
==== AUTHENTICATING FOR org.freedesktop.systemd1.manage-units ====
Authentication is required to restart 'bluetooth.service'.
Authenticating as: ,,, (vti)
Password: 
==== AUTHENTICATION COMPLETE ====
vti@rpi:~$ bluetoothctl
Agent registered
[bluetooth]# connect C1:1A:18:51:69:FC 
Attempting to connect to C1:1A:18:51:69:FC
[CHG] Device C1:1A:18:51:69:FC Connected: yes
Connection successful
````
