### PR TITLE
Add debug mode again

### DIFF
--- a/bicycleinit/device.py
+++ b/bicycleinit/device.py
@@ -108,6 +108,9 @@ class BicycleDevice:
     # LED2 indicates GPS status
     # LED3 indicates Radar status
 
+    bicyclebutton.start_bicyclebutton('bicyclebutton', {'session': self.session, 'gpio': 23, 'upload_interval': 300})
+    debug_mode = bicyclebutton._button.is_pressed
+    
     # Enable wifi
     time.sleep(1)
     bluetooth.off()
@@ -172,8 +175,9 @@ class BicycleDevice:
           logging.info(f"Installed requirements for {sensor['name']} from {req_path}")
         except Exception as e:
           logging.error(f"Failed to install requirements for {sensor['name']} from {req_path}: {e}")
-
-    self.stop_wifi()  # Disable WiFi to save power until needed again
+    
+    if not debug_mode:
+      self.stop_wifi()  # Disable WiFi to save power until needed again
 
     time.sleep(1)
     bluetooth.on()
@@ -186,7 +190,7 @@ class BicycleDevice:
       sensor['args']['session'] = self.session
       sensor_manager.start_sensor(sensor['name'], 'sensors.' + sensor['name'] + "." + file, fcn, sensor['args'])
 
-    bicyclebutton.start_bicyclebutton('bicyclebutton', {'session': self.session, 'gpio': 23, 'upload_interval': 300})
+    # bicyclebutton.start_bicyclebutton('bicyclebutton', {'session': self.session, 'gpio': 23, 'upload_interval': 300})
 
     while True:
       # Wait for any connection to become ready

--- a/bicycleinit/device.py
+++ b/bicycleinit/device.py
@@ -107,9 +107,6 @@ class BicycleDevice:
     # LED1 indicates WiFi connection status
     # LED2 indicates GPS status
     # LED3 indicates Radar status
-
-    bicyclebutton.start_bicyclebutton('bicyclebutton', {'session': self.session, 'gpio': 23, 'upload_interval': 300})
-    debug_mode = bicyclebutton._button.is_pressed
     
     # Enable wifi
     time.sleep(1)
@@ -176,6 +173,9 @@ class BicycleDevice:
         except Exception as e:
           logging.error(f"Failed to install requirements for {sensor['name']} from {req_path}: {e}")
     
+    bicyclebutton.start_bicyclebutton('bicyclebutton', {'session': self.session, 'gpio': 23, 'upload_interval': 300})
+    debug_mode = bicyclebutton._button.is_pressed
+
     if not debug_mode:
       self.stop_wifi()  # Disable WiFi to save power until needed again
 
@@ -189,8 +189,6 @@ class BicycleDevice:
       file, fcn = sensor['entry_point'].split(':')
       sensor['args']['session'] = self.session
       sensor_manager.start_sensor(sensor['name'], 'sensors.' + sensor['name'] + "." + file, fcn, sensor['args'])
-
-    # bicyclebutton.start_bicyclebutton('bicyclebutton', {'session': self.session, 'gpio': 23, 'upload_interval': 300})
 
     while True:
       # Wait for any connection to become ready


### PR DESCRIPTION
Debug mode keeps wifi on (which will interfere with bluetooth, but is ok for debug). It is useful when one wants to ssh into the Pi but does not have a LAN connection available. In a normal mode, wifi just turns off soon after boot and Pi is unreachable. 